### PR TITLE
Specify Blender 4.2 support, Add descriptions to some operators, Working Eevee Performance Checker

### DIFF
--- a/mmd_uuunyaa_tools/__init__.py
+++ b/mmd_uuunyaa_tools/__init__.py
@@ -28,7 +28,7 @@ bl_info = {
     "description": "Utility tools for MMD model & scene editing by Uuu(/>ω<)/Nyaa!.",
     "author": "UuuNyaa",
     "version": (4, 0, 0),
-    "blender": (4, 1, 0),
+    "blender": (4, 2, 0),
     "warning": "",
     "location": "View3D > Sidebar > MMD Tools Panel",
     "wiki_url": "https://github.com/UuuNyaa/blender_mmd_uuunyaa_tools/wiki",

--- a/mmd_uuunyaa_tools/checkers/operators.py
+++ b/mmd_uuunyaa_tools/checkers/operators.py
@@ -132,32 +132,12 @@ class CheckEeveeRenderingPerformance(bpy.types.Operator):
         )
 
     @classmethod
-    def check_use_gtao(cls, context: bpy.types.Context) -> CheckResult:
-        return CheckResult(
-            _("Use Ambient Occlusion"),
-            CheckResultStatus.AVERAGE if context.scene.eevee.use_gtao else CheckResultStatus.GOOD,
-            0 if context.scene.eevee.use_gtao else -3.9,
-            "scene.eevee.use_gtao",
-            _("= False is Good"),
-        )
-
-    @classmethod
-    def check_use_bloom(cls, context: bpy.types.Context) -> CheckResult:
-        return CheckResult(
-            _("Use Bloom"),
-            CheckResultStatus.AVERAGE if context.scene.eevee.use_bloom else CheckResultStatus.GOOD,
-            0 if context.scene.eevee.use_bloom else -2.9,
-            "scene.eevee.use_bloom",
-            _("= False is Good"),
-        )
-
-    @classmethod
     def check_use_motion_blur(cls, context: bpy.types.Context) -> CheckResult:
         return CheckResult(
             _("Use Motion Blur"),
-            CheckResultStatus.AVERAGE if context.scene.eevee.use_motion_blur else CheckResultStatus.GOOD,
-            0 if context.scene.eevee.use_motion_blur else -3.4,
-            "scene.eevee.use_motion_blur",
+            CheckResultStatus.AVERAGE if context.scene.render.use_motion_blur else CheckResultStatus.GOOD,
+            0 if context.scene.render.use_motion_blur else -3.4,
+            "scene.render.use_motion_blur",
             _("= False is Good"),
         )
 
@@ -181,49 +161,6 @@ class CheckEeveeRenderingPerformance(bpy.types.Operator):
             -0.0163 + 4.85e-03 * (math.log(context.scene.eevee.bokeh_max_size) if context.scene.eevee.bokeh_max_size != 0 else 0),
             "scene.eevee.bokeh_max_size",
             _("<= 16 is Good"),
-        )
-
-    @classmethod
-    def check_sss_samples(cls, context: bpy.types.Context) -> CheckResult:
-        status = CheckResultStatus.UNKNOWN
-        if context.scene.eevee.sss_samples == 32:
-            status = CheckResultStatus.BAD
-        elif context.scene.eevee.sss_samples > 16:
-            status = CheckResultStatus.POOR
-        elif context.scene.eevee.sss_samples > 8:
-            status = CheckResultStatus.WARNING
-        elif context.scene.eevee.sss_samples > 4:
-            status = CheckResultStatus.AVERAGE
-        else:
-            status = CheckResultStatus.GOOD
-
-        return CheckResult(
-            _("Subsurface Scattering Samples"),
-            status,
-            -8.22e-04 + 1.7e-04 * context.scene.eevee.sss_samples + 8.29e-06 * math.pow(context.scene.eevee.sss_samples, 2),
-            "scene.eevee.sss_samples",
-            _("<= 4 is Good"),
-        )
-
-    @classmethod
-    def check_use_ssr(cls, context: bpy.types.Context) -> CheckResult:
-        return CheckResult(
-            _("Use Screen Space Refraction"),
-            CheckResultStatus.WARNING if context.scene.eevee.use_ssr else CheckResultStatus.GOOD,
-            0 if context.scene.eevee.use_ssr else -11.4,
-            "scene.eevee.use_ssr",
-            _("= False is Good"),
-        )
-
-    @classmethod
-    def check_use_ssr_halfres(cls, context: bpy.types.Context) -> CheckResult:
-        return CheckResult(
-            _("Use Half Res Trace"),
-            CheckResultStatus.AVERAGE if not context.scene.eevee.use_ssr_halfres else CheckResultStatus.GOOD,
-            -2.2 if context.scene.eevee.use_ssr_halfres else 0,
-            "scene.eevee.use_ssr_halfres",
-            _("= True is Good"),
-            1,
         )
 
     @classmethod
@@ -356,16 +293,6 @@ class CheckEeveeRenderingPerformance(bpy.types.Operator):
         )
 
     @classmethod
-    def check_use_pass_bloom(cls, context: bpy.types.Context) -> CheckResult:
-        return CheckResult(
-            _("Pass Bloom"),
-            CheckResultStatus.WARNING if context.view_layer.eevee.use_pass_bloom else CheckResultStatus.GOOD,
-            -(-0.8 - 2.6) if context.view_layer.eevee.use_pass_bloom else 0,
-            "view_layer.eevee.use_pass_bloom",
-            _("= False is Good"),
-        )
-
-    @classmethod
     def check_use_pass_volume_direct(cls, context: bpy.types.Context) -> Optional[CheckResult]:
         if not hasattr(context.view_layer.eevee, "use_pass_volume_direct"):
             return None
@@ -443,72 +370,6 @@ class CheckEeveeRenderingPerformance(bpy.types.Operator):
 
         return (context, path_fragments[-1])
 
-    @classmethod
-    def check_meshes_use_auto_smooth(cls, context: bpy.types.Context) -> CheckResult:
-        mesh_count = 0
-        use_auto_smooth_mesh_count = 0
-
-        obj: bpy.types.Object
-        for obj in context.view_layer.objects:
-            if obj.type != "MESH":
-                continue
-
-            if obj.hide_render:
-                continue
-
-            mesh: bpy.types.Mesh = obj.data
-
-            mesh_count += 1
-
-            if not mesh.use_auto_smooth:
-                continue
-
-            use_auto_smooth_mesh_count += 1
-
-        return CheckResult(
-            _("Meshes Use Auto Smooth"),
-            CheckResultStatus.GOOD if use_auto_smooth_mesh_count == 0 else CheckResultStatus.WARNING,
-            min(use_auto_smooth_mesh_count * 0.7, 3),
-            f"{use_auto_smooth_mesh_count} / {mesh_count}",
-            _("= 0 is Good"),
-            editable=False,
-        )
-
-    @classmethod
-    def check_materials_method(cls, context: bpy.types.Context) -> CheckResult:
-        active_materials: Set[bpy.types.Material] = set()
-
-        obj: bpy.types.Object
-        for obj in context.view_layer.objects:
-            if obj.type != "MESH":
-                continue
-
-            if obj.hide_render:
-                continue
-
-            material_slot: bpy.types.MaterialSlot
-            for material_slot in obj.material_slots:
-                if material_slot.material is None:
-                    continue
-                active_materials.add(material_slot.material)
-
-        material_count = len(active_materials)
-        alpha_hashed_material_count = 0
-
-        for material in active_materials:
-            if material.blend_method != "HASHED" and material.shadow_method != "HASHED":
-                continue
-            alpha_hashed_material_count += 1
-
-        return CheckResult(
-            _("Materials Use Alpha Hashed"),
-            CheckResultStatus.GOOD if alpha_hashed_material_count == 0 else CheckResultStatus.WARNING,
-            min(alpha_hashed_material_count * 0.4, 2),
-            f"{alpha_hashed_material_count} / {material_count}",
-            _("= 0 is Good"),
-            editable=False,
-        )
-
     def draw(self, context: bpy.types.Context):
         layout: bpy.types.UILayout = self.layout
         layout.label(text=_("Eevee Rendering Performance Checker"), icon="MOD_TIME")
@@ -521,15 +382,10 @@ class CheckEeveeRenderingPerformance(bpy.types.Operator):
                     self.check_render_engine(context),
                     self.check_taa_render_samples(context),
                     self.check_taa_samples(context),
-                    self.check_use_gtao(context),
-                    self.check_use_bloom(context),
-                    self.check_bokeh_max_size(context),
-                    self.check_sss_samples(context),
-                    self.check_use_ssr(context),
-                    self.check_use_ssr_halfres(context),
                     self.check_use_motion_blur(context),
-                    self.check_file_format(context),
+                    self.check_bokeh_max_size(context),
                     self.check_use_compositing(context),
+                    self.check_file_format(context),
                     self.check_use_sequencer(context),
                     self.check_use_pass_z(context),
                     self.check_use_pass_normal(context),
@@ -542,12 +398,9 @@ class CheckEeveeRenderingPerformance(bpy.types.Operator):
                     self.check_use_pass_environment(context),
                     self.check_use_pass_shadow(context),
                     self.check_use_pass_ambient_occlusion(context),
-                    self.check_use_pass_bloom(context),
                     self.check_use_pass_cryptomatte_object(context),
                     self.check_use_pass_cryptomatte_material(context),
                     self.check_use_pass_cryptomatte_asset(context),
-                    self.check_meshes_use_auto_smooth(context),
-                    self.check_materials_method(context),
                 ],
             )
         )

--- a/mmd_uuunyaa_tools/converters/armatures/operators.py
+++ b/mmd_uuunyaa_tools/converters/armatures/operators.py
@@ -20,6 +20,7 @@ from mmd_uuunyaa_tools.utilities import MessageException, import_mmd_tools
 class MMDArmatureAddMetarig(bpy.types.Operator):
     bl_idname = "mmd_uuunyaa_tools.mmd_armature_add_metarig"
     bl_label = _("Add Human (metarig) from MMD Armature")
+    bl_description = _("Generate Human (metarig) from MMD Armature.")
     bl_options = {"REGISTER", "UNDO"}
 
     is_clean_armature: bpy.props.BoolProperty(name=_("Clean Armature"), default=True)
@@ -220,6 +221,7 @@ class MMDRigifyOperatorABC:
 class MMDRigifyIntegrateFocusOnMMD(MMDRigifyOperatorABC, bpy.types.Operator):
     bl_idname = "mmd_uuunyaa_tools.mmd_rigify_mmd_focused_integrate"
     bl_label = _("MMD compatibility focused Integrate")
+    bl_description = _("Combine Rigify rig and MMD armature.")
     bl_options = {"REGISTER", "UNDO"}
 
     is_join_armatures: bpy.props.BoolProperty(
@@ -271,6 +273,7 @@ class MMDRigifyIntegrateFocusOnMMD(MMDRigifyOperatorABC, bpy.types.Operator):
 class MMDRigifyIntegrateFocusOnRigify(bpy.types.Operator, MMDRigifyOperatorABC):
     bl_idname = "mmd_uuunyaa_tools.mmd_rigify_rigify_focused_integrate"
     bl_label = _("Rigify operability focused Integrate")
+    bl_description = _("Combine Rigify rig and MMD armature.")
     bl_options = {"REGISTER", "UNDO"}
 
     is_join_armatures: bpy.props.BoolProperty(

--- a/mmd_uuunyaa_tools/converters/physics/cloth_pyramid.py
+++ b/mmd_uuunyaa_tools/converters/physics/cloth_pyramid.py
@@ -866,6 +866,7 @@ def to_targets(
 class AddPyramidMeshByBreastBoneOperator(bpy.types.Operator):
     bl_idname = "mmd_uuunyaa_tools.add_pyramid_mesh_by_breast_bone"
     bl_label = _("Add Pyramid Mesh by Breast Bone")
+    bl_description = _("Add pyramid meshes from selected breast bones.")
     bl_options = {"REGISTER", "UNDO"}
 
     head_tail: bpy.props.FloatProperty(name=_("Head/Tail"), default=0.5, min=0.0, max=1.0, step=10)
@@ -913,6 +914,7 @@ class AddPyramidMeshByBreastBoneOperator(bpy.types.Operator):
 class ConvertPyramidMeshToClothOperator(bpy.types.Operator):
     bl_idname = "mmd_uuunyaa_tools.convert_pyramid_mesh_to_cloth"
     bl_label = _("Convert Pyramid Mesh to Cloth")
+    bl_description = _("Convert pyramid meshes to cloth simulation.")
     bl_options = {"REGISTER", "UNDO"}
 
     boundary_expansion_hop_count: bpy.props.IntProperty(name=_("Boundary Expansion Hop Count"), default=0, min=0, max=5)


### PR DESCRIPTION
## Blender 4.2 support
I think this addon should focus on Blender 4.2 and later, which uses newer Eevee.
This is called `BLENDER_EEVEE_NEXT`, unlike 4.0 & 4.1's legacy Eevee (`BLENDER_EEVEE`). 
Blender 5.0 will introduce `BLENDER_EEVEE` again, but it's basically the same as EEVEE Next, and it's still alpha so it doesn't matter.
Since support policy is the same as MMD Tools, which supports Blender LTS, we can dismiss Blender 4.0 & 4.1.

## Working Eevee Performance Checker
To fix non-functional performance checker, I removed checks like SSR and SSS samples, which have been removed in Blender 4.2. I have no idea how Performance Checker calculates performance, so I haven't added anything. It's now populated with some stats instead of hollow popup.

## Added some descriptions
I added `bl_description` to Rigify integration (metarig, mmd & rigify) and Pyramid cloth. I don't use anything besides these, so I can't add descriptions for others.