### PR TITLE
Fixed MMD Tools import and added missing import in `rigify.py`

### DIFF
--- a/mmd_tools_append/converters/armatures/rigify.py
+++ b/mmd_tools_append/converters/armatures/rigify.py
@@ -9,7 +9,7 @@ import bpy
 from mathutils import Color, Euler, Matrix, Vector
 
 from ...editors.armatures import DriverVariable, PoseBoneEditor
-from .mmd import MMDArmatureObject
+from .mmd import MMDArmatureObject, MMDBoneType
 from .mmd_bind import ControlType, DataPath, GroupType, MMDBindArmatureObjectABC, MMDBindInfo, MMDBindType, MMDBoneInfo
 
 

--- a/mmd_tools_append/utilities.py
+++ b/mmd_tools_append/utilities.py
@@ -70,8 +70,11 @@ def is_mmd_tools_installed():
     )
 
     for name in candidates:
-        if name in sys.modules or importlib.util.find_spec(name) is not None:
-            return True
+        try:
+            if name in sys.modules or importlib.util.find_spec(name) is not None:
+                return True
+        except:
+            pass
 
     return False
 


### PR DESCRIPTION
Missing features aside, this has to be fixed immediately. I added missing import `MMDBoneType` in `converters/armatures/rigify.py`, and fixed Append totally non-functional (at least on my env).